### PR TITLE
Fix stacked bar chart totals for eeaDataConnector data

### DIFF
--- a/src/plotly/chartDefinition.ts
+++ b/src/plotly/chartDefinition.ts
@@ -71,7 +71,7 @@ const getChartData = (
   chartData?.ySeries.map((series: any, index: number) => {
     // Calculate the Y value totals across all series
     for (let i = 0; i < series.values.length; i++) {
-      totals[i] += parseInt(series.values[i]);
+      totals[i] += parseFloat(series.values[i]);
     }
     let trace: {};
 

--- a/src/plotly/chartDefinition.ts
+++ b/src/plotly/chartDefinition.ts
@@ -71,9 +71,8 @@ const getChartData = (
   chartData?.ySeries.map((series: any, index: number) => {
     // Calculate the Y value totals across all series
     for (let i = 0; i < series.values.length; i++) {
-      totals[i] += series.values[i];
+      totals[i] += parseInt(series.values[i]);
     }
-
     let trace: {};
 
     if (chartProps.orientationProperties.orientation === "horizontal") {


### PR DESCRIPTION
eeaDataConnector data returns y series values as an array of strings, whereas tidyDataConnector returns them as numbers. 

- The fix uses parseInt to convert the strings to numbers in chartDefinition.ts
- Issue #346 aims to solve the problem at source.

Closes #112