### PR TITLE
Implement user configurable x and y axis types

### DIFF
--- a/src/context/ChartPropertiesSchema.ts
+++ b/src/context/ChartPropertiesSchema.ts
@@ -83,6 +83,13 @@ const xAxisSection: ChartPropertySchemaSection = {
       defaultValue: "",
     },
     {
+      name: "xAxisType",
+      displayName: "Type",
+      type: "radio",
+      options: ["auto", "linear", "log", "date", "category", "multicategory"],
+      defaultValue: "auto",
+    },
+    {
       name: "xAxisRangeMode",
       displayName: "Range mode",
       type: "radio",
@@ -115,6 +122,13 @@ const yAxisSection: ChartPropertySchemaSection = {
       displayName: "Title",
       type: "text",
       defaultValue: "",
+    },
+    {
+      name: "yAxisType",
+      displayName: "Type",
+      type: "radio",
+      options: ["auto", "linear", "log", "date", "category", "multicategory"],
+      defaultValue: "-",
     },
     {
       name: "yHoverInfoPrecision",

--- a/src/context/ChartPropertiesSchema.ts
+++ b/src/context/ChartPropertiesSchema.ts
@@ -128,7 +128,7 @@ const yAxisSection: ChartPropertySchemaSection = {
       displayName: "Type",
       type: "radio",
       options: ["auto", "linear", "log", "date", "category", "multicategory"],
-      defaultValue: "-",
+      defaultValue: "auto",
     },
     {
       name: "yHoverInfoPrecision",

--- a/src/plotly/layout.ts
+++ b/src/plotly/layout.ts
@@ -33,14 +33,22 @@ const getCommonLayout = (chartProps: ChartPropertyValues) => {
   };
 };
 
+// If the axis type is "auto" then set it to (non human readable) "-" that Plotly understands
+const getAxisType = (axisType: string) =>
+  axisType === "auto" ? "-" : axisType;
+
 const getChartLayout = (chartProps: ChartPropertyValues) => {
   const commonLayout = getCommonLayout(chartProps);
   const barmode = inferBarMode(chartProps.chartTypes.chartType as any);
+
+  const xAxisType = getAxisType(chartProps.xAxisProperties.xAxisType as string);
+  const yAxisType = getAxisType(chartProps.yAxisProperties.yAxisType as string);
 
   const chartLayout = {
     barmode,
     xaxis: {
       autorange: true,
+      type: xAxisType,
       rangemode: chartProps.xAxisProperties.xAxisRangeMode,
       fixedrange: true, // prevents the user from zooming in/out
       showgrid: chartProps.Gridlines.showGridLines,
@@ -53,6 +61,7 @@ const getChartLayout = (chartProps: ChartPropertyValues) => {
     },
     yaxis: {
       autorange: true,
+      type: yAxisType,
       rangemode: chartProps.yAxisProperties.yAxisRangeMode,
       fixedrange: true, // prevents the user from zooming in/out
       showgrid: chartProps.Gridlines.showGridLines,


### PR DESCRIPTION
- Add the properties to schema
- Apply the user's choice in the Plotly layout
- Map user friendly 'auto' to Plotly '-' for automatic axis type

Closes #129 