### PR TITLE
Add support for sparse datasets

### DIFF
--- a/src/context/types.ts
+++ b/src/context/types.ts
@@ -4,7 +4,7 @@ interface DataColumn {
 }
 
 interface ChartData {
-  xValues: DataColumn;
+  xValues: DataColumn[];
   yValues: DataColumn[];
 }
 

--- a/src/plotly/chartDefinition.ts
+++ b/src/plotly/chartDefinition.ts
@@ -70,15 +70,16 @@ const getChartData = (
   allYSeries.map((series: any, seriesIndex: number) => {
     // If it's a stacked bar chart then calculate the cross-series totals
     if (isAStackedBar) {
-      // Iterate through each of the unique X values (non sparse X values)
-      for (let i = 0; i < uniqueXValues.length; i++) {
-        const xValue = uniqueXValues[i];
+      const currentXValues = xValues[seriesIndex].values;
+      // // Iterate through each of the X values in the current (potentially sparse) series
+      for (let i = 0; i < currentXValues.length; i++) {
+        // Get the current X and Y values in the (potentially sparse) series
+        const xValue = currentXValues[i];
         const yValue = series.values[i];
 
-        // Update the total for this point on the category axis with the Y value if there's a sparse X match
-        if (xValues[seriesIndex].values.includes(xValue)) {
-          totals[i] += parseFloat(yValue);
-        }
+        // Find which index to update in the (non sparse) totals array.
+        const indexToUpdate = uniqueXValues.indexOf(xValue);
+        totals[indexToUpdate] += parseFloat(yValue);
       }
     }
     let trace: {};


### PR DESCRIPTION
- Adjust the data pivot logic that extracts series from tidy data so it retains the X values for each series and passes them through to  the chart definition logic
- Adapt the stacked bar chart totals logic to support sparse datasets
- Add check for empty chart data in chartDefinition.ts after switching from map to chart types  
- Refactoring and commenting the data loading logic for improved code readability

Closes #139 