### PR TITLE
 CSV parsing fix for Windows line endings

### DIFF
--- a/src/context/useChartCsvData.ts
+++ b/src/context/useChartCsvData.ts
@@ -1,6 +1,21 @@
 import Papa from "papaparse";
 import { Dispatch, SetStateAction, useCallback } from "react";
 
+const parseText = (
+  text: string,
+  onComplete: (results: Papa.ParseResult<unknown>) => any,
+) => {
+  // Replace CRLF with LF to fix parsing issues with Windows line endings
+  text = text.replace(/[\r\n]+/g, "\n");
+  Papa.parse(text, {
+    worker: true,
+    header: true,
+    skipEmptyLines: true,
+    dynamicTyping: true,
+    complete: onComplete,
+  });
+};
+
 function useChartCsvData(
   setTidyData: Dispatch<SetStateAction<any>>,
   setSelectedFilename: Dispatch<SetStateAction<string>>,
@@ -11,20 +26,22 @@ function useChartCsvData(
 
   const importCsvData = useCallback(
     (data: File | string, filename: string) => {
-      Papa.parse(data, {
-        worker: true,
-        header: true,
-        skipEmptyLines: true,
-        dynamicTyping: true,
-        complete: function (results) {
-          if (results.errors && results.errors.length > 0) {
-            onFailure(results.errors[0].message);
-          } else {
-            setSelectedFilename(filename);
-            setTidyData(results.data);
-          }
-        },
-      });
+      const onComplete = (results: Papa.ParseResult<unknown>) => {
+        if (results.errors && results.errors.length > 0) {
+          onFailure(results.errors[0].message);
+        } else {
+          setSelectedFilename(filename);
+          setTidyData(results.data);
+        }
+      };
+
+      if (typeof data === "string") {
+        parseText(data, onComplete);
+      } else {
+        data.text().then((text) => {
+          parseText(text, onComplete);
+        });
+      }
     },
     [setSelectedFilename, setTidyData],
   );


### PR DESCRIPTION
 - Replace `Windows` line endings `\r\n` with `Unix` ones `\n` in useCsvDData hook
 - Required for `papaparse` library to work correctly with Windows CSVs
 - Resolution described here https://github.com/mholt/PapaParse/issues/289

Closes #147 