### PR TITLE
Add chart property for displaying marker dots on line series

### DIFF
--- a/src/context/ChartPropertiesSchema.ts
+++ b/src/context/ChartPropertiesSchema.ts
@@ -17,6 +17,13 @@ const legendSection: ChartPropertySchemaSection = {
       type: "text",
       defaultValue: -0.11,
     },
+    {
+      name: "mode",
+      displayName: "Lines and markers",
+      type: "radio",
+      options: ["lines", "lines+markers", "markers"],
+      defaultValue: "lines",
+    },
   ],
 };
 

--- a/src/plotly/chartDefinition.ts
+++ b/src/plotly/chartDefinition.ts
@@ -108,7 +108,7 @@ const getChartData = (
       ...trace,
       name: series.name,
       type: chartType === "stacked bar" ? "bar" : chartType,
-      mode: "lines",
+      mode: chartProps?.LegendSection?.mode ?? "lines",
       hoverinfo: chartProps.Interactivity.interactivity,
       marker: { color: series.color },
       line: {


### PR DESCRIPTION
- This can be useful for highlighting data points that are separate to the main series
- Note that Plotly automatically adds padding to the left and right of the series when marker dots are selected. This behaviour is discussed here: https://github.com/plotly/plotly.js/issues/1876