### PR TITLE
Basic implementation of filled area plots.

### DIFF
--- a/src/context/ChartPropertiesSchema.ts
+++ b/src/context/ChartPropertiesSchema.ts
@@ -51,7 +51,7 @@ const chartTypesSection: ChartPropertySchemaSection = {
       displayName: "",
       showPropertyLabel: false,
       type: "radio",
-      options: ["Line", "Bar", "Stacked Bar", "Map"],
+      options: ["Line", "Filled Area", "Bar", "Stacked Bar", "Map"],
       defaultValue: "Line",
     },
   ],

--- a/src/plotly/chartDefinition.ts
+++ b/src/plotly/chartDefinition.ts
@@ -129,6 +129,7 @@ const getChartData = (
         color: series.color,
         dash: series.dashStyle,
       },
+      fill: chartType === "filled area" ? "tonexty" : "none",
     };
     isAStackedBar ? traces.unshift(newSeries) : traces.push(newSeries);
   });


### PR DESCRIPTION
- Configured to fill to next Y series line
- Future iterations might want to consider offering options for filling to zero or to next Y

Note: Users should set the Y axis range mode 'tozero' for this chart type to accurately show the area under the line.

Closes #158