### PR TITLE
Conditionally load Plotly basic or geo bundles

### DIFF
--- a/src/components/chart-preview/ChartPreview.tsx
+++ b/src/components/chart-preview/ChartPreview.tsx
@@ -3,15 +3,17 @@ import ChartContext from "../../context/ChartContext";
 import ChartPlaceholderIcon from "../../assets/icons/chart-preview/ChartPlaceholderIcon";
 import "./chart-preview.css";
 
+// @ts-ignore
+const PlotlyBasic = lazy(() => import("./PlotlyBasic"));
+// @ts-ignore
+const PlotlyGeo = lazy(() => import("./PlotlyGeo"));
+
 const ChartPreview = (): JSX.Element => {
   const { chartDefinition }: any = useContext(ChartContext);
   return <ActualChart chartDefinition={chartDefinition} />;
 };
 
 const isClientSideRender = typeof window !== "undefined";
-
-// @ts-ignore - issue related to the way react-plotly Plot is exported
-const Plot = isClientSideRender ? lazy(() => import("react-plotly.js")) : null;
 
 export const ActualChart = ({ chartDefinition }: any): JSX.Element => {
   const emptyDataState = Object.keys(chartDefinition).length === 0;
@@ -25,8 +27,7 @@ export const ActualChart = ({ chartDefinition }: any): JSX.Element => {
       </div>
     );
 
-  let { data, layout, config } = chartDefinition;
-
+  const { chartType, layout } = chartDefinition;
   // Incrementing the datarevision forces plotly to update the chart.
   // This is a workaround for an issue where plotly loses its
   // autorange calculations on component re-render.
@@ -34,17 +35,15 @@ export const ActualChart = ({ chartDefinition }: any): JSX.Element => {
 
   return (
     <div id="chart">
-      {Plot ? (
-        <Suspense fallback={<div />}>
-          <Plot
-            data={data}
-            layout={layout}
-            config={config}
-            useResizeHandler={true}
-            style={{ width: "100%" }}
-          />
-        </Suspense>
-      ) : null}
+      <Suspense fallback={<div />}>
+        {isClientSideRender ? (
+          chartType === "map" ? (
+            <PlotlyGeo chartDefinition={chartDefinition} />
+          ) : (
+            <PlotlyBasic chartDefinition={chartDefinition} />
+          )
+        ) : null}
+      </Suspense>
     </div>
   );
 };

--- a/src/components/chart-preview/PlotlyBasic.tsx
+++ b/src/components/chart-preview/PlotlyBasic.tsx
@@ -1,0 +1,21 @@
+// @ts-ignore
+import Plotly from "plotly.js-basic-dist-min";
+import createPlotlyComponent from "react-plotly.js/factory";
+
+const Plot: any = createPlotlyComponent(Plotly);
+
+const PlotlyBasic = ({ chartDefinition }: any) => {
+  let { data, layout, config } = chartDefinition;
+
+  return (
+    <Plot
+      data={data}
+      layout={layout}
+      config={config}
+      useResizeHandler={true}
+      style={{ width: "100%" }}
+    />
+  );
+};
+
+export default PlotlyBasic;

--- a/src/components/chart-preview/PlotlyGeo.tsx
+++ b/src/components/chart-preview/PlotlyGeo.tsx
@@ -1,0 +1,21 @@
+// @ts-ignore
+import Plotly from "plotly.js-geo-dist-min";
+import createPlotlyComponent from "react-plotly.js/factory";
+
+const Plot: any = createPlotlyComponent(Plotly);
+
+const PlotlyGeo = ({ chartDefinition }: any) => {
+  let { data, layout, config } = chartDefinition;
+
+  return (
+    <Plot
+      data={data}
+      layout={layout}
+      config={config}
+      useResizeHandler={true}
+      style={{ width: "100%" }}
+    />
+  );
+};
+
+export default PlotlyGeo;

--- a/src/plotly/chartDefinition.ts
+++ b/src/plotly/chartDefinition.ts
@@ -27,7 +27,7 @@ const updateChartDefinition = (
     ? (layout = getMapLayout(chartProps))
     : (layout = getChartLayout(chartProps, data));
 
-  return { data, layout, config };
+  return { data, layout, config, chartType };
 };
 
 const getChartData = (


### PR DESCRIPTION
- Create two separate components to render Plotly, one for the basic charts and one for maps
- Each of the above components has the import statement for the required sub-bundle
- Lazily load the required Plotly component based on whether we want to show a chart or a map

Notes:

We have to lazily load Plotly to prevent SSR errors (as in the previous implementation)
The sub component approach was necessary because there's no way to conditionally and lazily load and use the sub bundles in one component.
Solution assumes bundles to be installed locally:

In dd-cms:

`yarn add plotly.js-geo-dist-min -W`   
`yarn add plotly.js-basic-dist-min -W` 

In Chart builder:

`yarn add plotly.js-geo-dist-min`   
`yarn add plotly.js-basic-dist-min` 

Closes #138