### PR TITLE
Issue 149/compact horizontal bar charts

### DIFF
--- a/src/components/side-panel/SidePanel.tsx
+++ b/src/components/side-panel/SidePanel.tsx
@@ -132,7 +132,9 @@ const SidePanel = ({
 
   const shouldShowSection = ({ name, sectionFor }: any): boolean => {
     if (isACompactBar) {
-      return name === "chartDimensionProperties" || name === "chartTypes"
+      return name === "chartDimensionProperties" ||
+        name === "chartTypes" ||
+        name === "compactBarChartProperties"
         ? true
         : false;
     }

--- a/src/components/side-panel/SidePanel.tsx
+++ b/src/components/side-panel/SidePanel.tsx
@@ -90,6 +90,9 @@ const SidePanel = ({
 
   const isAMap = chartProperties?.chartTypes?.chartType === "Map";
 
+  const isACompactBar =
+    chartProperties?.chartTypes?.chartType === "Compact Bar";
+
   const isAutoXTickMode =
     chartProperties.xAxisProperties.xAxisTickMode === "auto";
 
@@ -127,14 +130,24 @@ const SidePanel = ({
     return true;
   };
 
+  const shouldShowSection = ({ name, sectionFor }: any): boolean => {
+    if (isACompactBar) {
+      return name === "chartDimensionProperties" || name === "chartTypes"
+        ? true
+        : false;
+    }
+
+    return (
+      sectionFor === "all" ||
+      (sectionFor === "maps" && isAMap) ||
+      (sectionFor === "charts" && !isAMap)
+    );
+  };
+
   return (
     <div id="side-panel">
       {chartPropertiesSchema.map((section: any, index: number) => {
-        const showSection =
-          section.sectionFor === "all" ||
-          (section.sectionFor === "maps" && isAMap) ||
-          (section.sectionFor === "charts" && !isAMap);
-
+        const showSection = shouldShowSection(section);
         // Show sections relevant to the visualisation type (chart/map/all)
         if (!showSection) return null;
 

--- a/src/context/ChartPropertiesSchema.ts
+++ b/src/context/ChartPropertiesSchema.ts
@@ -340,8 +340,14 @@ const compactBarChartSection: ChartPropertySchemaSection = {
   sectionFor: "compactBarCharts",
   properties: [
     {
+      name: "valuePrefix",
+      displayName: "Prefix",
+      type: "text",
+      defaultValue: "",
+    },
+    {
       name: "unitOfMeasurement",
-      displayName: "Unit of measurement",
+      displayName: "Unit",
       type: "text",
       defaultValue: "",
     },

--- a/src/context/ChartPropertiesSchema.ts
+++ b/src/context/ChartPropertiesSchema.ts
@@ -55,6 +55,7 @@ const chartTypesSection: ChartPropertySchemaSection = {
         "Line",
         "Bar",
         "Stacked Bar",
+        "Compact Bar",
         "Map",
         "Filled Area",
         "Stacked Filled Area",

--- a/src/context/ChartPropertiesSchema.ts
+++ b/src/context/ChartPropertiesSchema.ts
@@ -334,6 +334,26 @@ const colorBarSection: ChartPropertySchemaSection = {
   ],
 };
 
+const compactBarChartSection: ChartPropertySchemaSection = {
+  name: "compactBarChartProperties",
+  displayName: "Compact bar chart",
+  sectionFor: "compactBarCharts",
+  properties: [
+    {
+      name: "unitOfMeasurement",
+      displayName: "Unit of measurement",
+      type: "text",
+      defaultValue: "",
+    },
+    {
+      name: "decimalPrecision",
+      displayName: "Decimal precision",
+      type: "text",
+      defaultValue: "",
+    },
+  ],
+};
+
 const chartPropertiesSchema: ChartPropertySchemaSection[] = [
   chartTypesSection,
   orientationSection,
@@ -343,6 +363,7 @@ const chartPropertiesSchema: ChartPropertySchemaSection[] = [
   legendSection,
   colorBarSection,
   interactivitySection,
+  compactBarChartSection,
 ];
 
 export default chartPropertiesSchema;

--- a/src/plotly/chartDefinition.ts
+++ b/src/plotly/chartDefinition.ts
@@ -29,13 +29,8 @@ const updateChartDefinition = (
     ? (layout = getMapLayout(chartProps))
     : (layout = getChartLayout(chartProps, data));
 
-  const isHorizontal =
-    chartProps.orientationProperties.orientation === "horizontal";
-
-  const allYSeries = chartData?.yValues;
-
   if (chartType === "compact bar") {
-    data = getCompactBarTraces(chartData);
+    data = getCompactBarTraces(chartData, chartProps);
     layout = getCompactBarLayout(chartData, chartProps);
   }
 

--- a/src/plotly/chartDefinition.ts
+++ b/src/plotly/chartDefinition.ts
@@ -3,6 +3,8 @@ import config from "./config";
 import { divergingColorScale, sequentialColorScale } from "./colorScales";
 import { GeoJSON } from "geojson";
 import { ChartPropertyValues } from "../context/ChartContext";
+import SeriesProperties from "../components/side-panel/property-inputs/SeriesProperties";
+import { getCompactBarTraces, getCompactBarLayout } from "./compactBarChart";
 
 const updateChartDefinition = (
   chartProps: ChartPropertyValues,
@@ -26,6 +28,16 @@ const updateChartDefinition = (
   chartType === "map"
     ? (layout = getMapLayout(chartProps))
     : (layout = getChartLayout(chartProps, data));
+
+  const isHorizontal =
+    chartProps.orientationProperties.orientation === "horizontal";
+
+  const allYSeries = chartData?.yValues;
+
+  if (chartType === "compact bar") {
+    data = getCompactBarTraces(chartData);
+    layout = getCompactBarLayout(chartData, chartProps);
+  }
 
   return { data, layout, config };
 };
@@ -66,6 +78,9 @@ const getChartData = (
   // Initialise an array to hold the cross-series totals for each point on the category axis
   let totals = new Array(uniqueXValues.length).fill(0);
 
+  const isHorizontal =
+    chartProps.orientationProperties.orientation === "horizontal";
+
   // Iterate the available series and create a trace for each
   allYSeries.map((series: any, seriesIndex: number) => {
     // If it's a stacked bar chart then calculate the cross-series totals
@@ -88,7 +103,7 @@ const getChartData = (
       chartProps.yAxisProperties.yHoverInfoPrecision as string,
     );
 
-    if (chartProps.orientationProperties.orientation === "horizontal") {
+    if (isHorizontal) {
       trace = {
         x: series.values,
         y: xValues[seriesIndex].values,

--- a/src/plotly/chartDefinition.ts
+++ b/src/plotly/chartDefinition.ts
@@ -1,9 +1,8 @@
-import { getChartLayout, getMapLayout } from "./layout";
+import { getChartLayout, getCommonLayout, getMapLayout } from "./layout";
 import config from "./config";
 import { divergingColorScale, sequentialColorScale } from "./colorScales";
 import { GeoJSON } from "geojson";
 import { ChartPropertyValues } from "../context/ChartContext";
-import SeriesProperties from "../components/side-panel/property-inputs/SeriesProperties";
 import { getCompactBarTraces, getCompactBarLayout } from "./compactBarChart";
 
 const updateChartDefinition = (
@@ -31,7 +30,9 @@ const updateChartDefinition = (
 
   if (chartType === "compact bar") {
     data = getCompactBarTraces(chartData, chartProps);
-    layout = getCompactBarLayout(chartData, chartProps);
+    const compactBarLayout = getCompactBarLayout(chartData, chartProps);
+    const commonLayout = getCommonLayout(chartProps);
+    layout = { ...commonLayout, ...compactBarLayout };
   }
 
   return { data, layout, config };

--- a/src/plotly/chartDefinition.ts
+++ b/src/plotly/chartDefinition.ts
@@ -30,7 +30,7 @@ const updateChartDefinition = (
 
   if (chartType === "compact bar") {
     data = getCompactBarTraces(chartData, chartProps);
-    const compactBarLayout = getCompactBarLayout(chartData, chartProps);
+    const compactBarLayout = getCompactBarLayout(chartData);
     const commonLayout = getCommonLayout(chartProps);
     layout = { ...commonLayout, ...compactBarLayout };
   }

--- a/src/plotly/compactBarChart.ts
+++ b/src/plotly/compactBarChart.ts
@@ -13,7 +13,7 @@ const categoryAnnotationProps = {
   xanchor: "left",
   font: {
     color: "#505a5f",
-    size: "16",
+    size: "14",
     family: "Arial",
   },
 };
@@ -81,7 +81,7 @@ const getCompactBarLayout = (data: any, chartProps: ChartPropertyValues) => {
     grid: {
       rows: data.xValues[0].values.length,
       columns: 1,
-      ygap: 0.1,
+      ygap: 0.15,
     },
     ...annotations,
   };
@@ -99,7 +99,7 @@ const getCompactBarTraces = (data: any) => {
       text: [data.yValues[0].values[i]],
       textposition: "auto",
       textfont: {
-        size: "16",
+        size: "14",
         family: "Arial",
       },
       yaxis: i === 0 ? "y" : "y" + (i + 1),

--- a/src/plotly/compactBarChart.ts
+++ b/src/plotly/compactBarChart.ts
@@ -81,7 +81,7 @@ const getCompactBarLayout = (data: any, chartProps: ChartPropertyValues) => {
     grid: {
       rows: data.xValues[0].values.length,
       columns: 1,
-      ygap: 0.15,
+      ygap: 0.05,
     },
     ...annotations,
   };

--- a/src/plotly/compactBarChart.ts
+++ b/src/plotly/compactBarChart.ts
@@ -1,10 +1,5 @@
 import { ChartPropertyValues } from "../context/ChartContext";
 
-const commonTraceProps = {
-  type: "bar",
-  orientation: "h",
-};
-
 const categoryAnnotationProps = {
   xref: "x",
   x: 0,
@@ -40,35 +35,16 @@ const getYAxesLayout = (seriesCount: number) => {
 };
 
 const getCompactBarLayout = (data: any, chartProps: ChartPropertyValues) => {
-  let annotations;
   let categoryAnnotations = [];
 
   for (let i = 0; i < data.xValues[0].values.length; i++) {
     categoryAnnotations.push(getCategoryAnnotation(data, i));
   }
 
-  annotations = { annotations: [...categoryAnnotations] };
-
-  const {
-    height: rawHeight,
-    marginLeft,
-    marginRight,
-    marginBottom,
-    marginTop,
-  } = chartProps.chartDimensionProperties;
-
-  const height: number = parseInt(rawHeight as any);
+  const annotations = { annotations: [...categoryAnnotations] };
 
   const yAxesLayout = getYAxesLayout(data.xValues[0].values.length);
   const layout = {
-    height: height,
-    margin: {
-      l: marginLeft,
-      r: marginRight,
-      b: marginBottom,
-      t: marginTop,
-      pad: 4,
-    },
     showlegend: false,
     autosize: true,
     xaxis: {
@@ -112,7 +88,8 @@ const getCompactBarTraces = (data: any, chartProps: any) => {
       yaxis: i === 0 ? "y" : "y" + (i + 1),
       marker: { color: seriesColor },
       hoverinfo: "none",
-      ...commonTraceProps,
+      type: "bar",
+      orientation: "h",
     };
 
     traces.push(trace);

--- a/src/plotly/compactBarChart.ts
+++ b/src/plotly/compactBarChart.ts
@@ -93,7 +93,7 @@ const getCompactBarTraces = (data: any, chartProps: any) => {
   let traces: any = [];
 
   const barChartProps = chartProps.compactBarChartProperties;
-  const { unitOfMeasurement, decimalPrecision } = barChartProps;
+  const { valuePrefix, unitOfMeasurement, decimalPrecision } = barChartProps;
   const seriesColor = data.yValues[0].color;
 
   for (let i = 0; i < data.xValues[0].values.length; i++) {
@@ -103,7 +103,7 @@ const getCompactBarTraces = (data: any, chartProps: any) => {
     let trace: any = {
       y: [data.xValues[0].values[i]],
       x: [data.yValues[0].values[i]],
-      text: formattedValue + unitOfMeasurement + " ",
+      text: valuePrefix + formattedValue + unitOfMeasurement + " ",
       textposition: "auto",
       textfont: {
         size: "14",

--- a/src/plotly/compactBarChart.ts
+++ b/src/plotly/compactBarChart.ts
@@ -3,7 +3,7 @@ import { ChartPropertyValues } from "../context/ChartContext";
 const categoryAnnotationProps = {
   xref: "x",
   x: 0,
-  y: 0.65,
+  y: 0.67,
   showarrow: false,
   xanchor: "left",
   font: {
@@ -57,7 +57,7 @@ const getCompactBarLayout = (data: any, chartProps: ChartPropertyValues) => {
     grid: {
       rows: data.xValues[0].values.length,
       columns: 1,
-      ygap: 0.05,
+      ygap: 0.08,
     },
     ...annotations,
   };

--- a/src/plotly/compactBarChart.ts
+++ b/src/plotly/compactBarChart.ts
@@ -1,0 +1,153 @@
+import { ChartPropertyValues } from "../context/ChartContext";
+
+const commonTraceProps = {
+  type: "bar",
+  orientation: "h",
+};
+
+const commonFontProps = {
+  size: "16",
+  family: "Arial",
+};
+
+const categoryAnnotationFont = {
+  font: {
+    color: "#505a5f",
+    ...commonFontProps,
+  },
+};
+
+const valueAnnotationFont = {
+  font: {
+    align: "right",
+    color: "#ffffff",
+    ...commonFontProps,
+  },
+};
+
+const categoryAnnotationProps = {
+  xref: "x",
+  x: 0,
+  y: 0.65,
+  showarrow: false,
+  xanchor: "left",
+  ...categoryAnnotationFont,
+};
+
+const valueAnnotationProps = {
+  xref: "x",
+  y: 0,
+  showarrow: false,
+  xanchor: "right",
+  xshift: -5,
+  ...valueAnnotationFont,
+};
+
+// calculate the length of plotly annotation text
+const getTextLength = (text: string) => {
+  const textLength = text.length;
+  return textLength * 8;
+};
+
+const getCategoryAnnotation = (data: any, index: number) => {
+  console.log(data.yValues[0].values[index]);
+  return {
+    yref: index === 0 ? "y" : "y" + (index + 1),
+    text: data.xValues[0].values[index],
+    ...categoryAnnotationProps,
+  };
+};
+
+const getValueAnnotation = (data: any, index: number) => {
+  return {
+    x: data.yValues[0].values[index],
+    yref: index === 0 ? "y" : "y" + (index + 1),
+    text: data.yValues[0].values[index] + "%",
+    ...valueAnnotationProps,
+  };
+};
+
+const getYAxesLayout = (seriesCount: number) => {
+  let yAxesLayout = {};
+
+  for (let i = 0; i < seriesCount; i++) {
+    const newYAxis = i === 0 ? "yaxis" : "yaxis" + (i + 1);
+    yAxesLayout = {
+      [newYAxis]: { showticklabels: false, fixedrange: true },
+      ...yAxesLayout,
+    };
+  }
+  return yAxesLayout;
+};
+
+const getCompactBarLayout = (data: any, chartProps: ChartPropertyValues) => {
+  let annotations;
+  let categoryAnnotations = [];
+  let valueAnnotations = [];
+
+  for (let i = 0; i < data.xValues[0].values.length; i++) {
+    categoryAnnotations.push(getCategoryAnnotation(data, i));
+    valueAnnotations.push(getValueAnnotation(data, i));
+  }
+
+  annotations = { annotations: [...categoryAnnotations, ...valueAnnotations] };
+
+  const {
+    height: rawHeight,
+    marginLeft,
+    marginRight,
+    marginBottom,
+    marginTop,
+  } = chartProps.chartDimensionProperties;
+
+  const height: number = parseInt(rawHeight as any);
+
+  const yAxesLayout = getYAxesLayout(data.xValues[0].values.length);
+  const layout = {
+    height: height,
+    margin: {
+      l: marginLeft,
+      r: marginRight,
+      b: marginBottom,
+      t: marginTop,
+      pad: 4,
+    },
+    showlegend: false,
+    autosize: true,
+    xaxis: {
+      showticklabels: false,
+      showgrid: false,
+      zeroline: false,
+      fixedrange: true, // prevents the user from zooming in/out
+    },
+    ...yAxesLayout,
+    grid: {
+      rows: data.xValues[0].values.length,
+      columns: 1,
+      ygap: 0.1,
+    },
+    ...annotations,
+  };
+
+  return layout;
+};
+
+const getCompactBarTraces = (data: any) => {
+  let traces: any = [];
+  const seriesColor = data.yValues[0].color;
+  for (let i = 0; i < data.xValues[0].values.length; i++) {
+    let trace: any = {
+      y: [data.xValues[0].values[i]],
+      x: [data.yValues[0].values[i]],
+      yaxis: i === 0 ? "y" : "y" + (i + 1),
+      marker: { color: seriesColor },
+      hoverinfo: "none",
+      ...commonTraceProps,
+    };
+
+    traces.push(trace);
+  }
+  return traces;
+};
+
+export { getCompactBarTraces, getCompactBarLayout };

--- a/src/plotly/compactBarChart.ts
+++ b/src/plotly/compactBarChart.ts
@@ -89,14 +89,21 @@ const getCompactBarLayout = (data: any, chartProps: ChartPropertyValues) => {
   return layout;
 };
 
-const getCompactBarTraces = (data: any) => {
+const getCompactBarTraces = (data: any, chartProps: any) => {
   let traces: any = [];
+
+  const barChartProps = chartProps.compactBarChartProperties;
+  const { unitOfMeasurement, decimalPrecision } = barChartProps;
   const seriesColor = data.yValues[0].color;
+
   for (let i = 0; i < data.xValues[0].values.length; i++) {
+    const value = [data.yValues[0].values[i]].toString();
+    const formattedValue = parseFloat(value).toFixed(decimalPrecision);
+
     let trace: any = {
       y: [data.xValues[0].values[i]],
       x: [data.yValues[0].values[i]],
-      text: [data.yValues[0].values[i]],
+      text: formattedValue + unitOfMeasurement + " ",
       textposition: "auto",
       textfont: {
         size: "14",

--- a/src/plotly/compactBarChart.ts
+++ b/src/plotly/compactBarChart.ts
@@ -5,65 +5,24 @@ const commonTraceProps = {
   orientation: "h",
 };
 
-const commonFontProps = {
-  size: "16",
-  family: "Arial",
-};
-
-const categoryAnnotationFont = {
-  font: {
-    color: "#505a5f",
-    ...commonFontProps,
-  },
-};
-
-const valueAnnotationFont = {
-  font: {
-    align: "right",
-    color: "#ffffff",
-    ...commonFontProps,
-  },
-};
-
 const categoryAnnotationProps = {
   xref: "x",
   x: 0,
   y: 0.65,
   showarrow: false,
   xanchor: "left",
-  ...categoryAnnotationFont,
-};
-
-const valueAnnotationProps = {
-  xref: "x",
-  y: 0,
-  showarrow: false,
-  xanchor: "right",
-  xshift: -5,
-  ...valueAnnotationFont,
-};
-
-// calculate the length of plotly annotation text
-const getTextLength = (text: string) => {
-  const textLength = text.length;
-  return textLength * 8;
+  font: {
+    color: "#505a5f",
+    size: "16",
+    family: "Arial",
+  },
 };
 
 const getCategoryAnnotation = (data: any, index: number) => {
-  console.log(data.yValues[0].values[index]);
   return {
     yref: index === 0 ? "y" : "y" + (index + 1),
     text: data.xValues[0].values[index],
     ...categoryAnnotationProps,
-  };
-};
-
-const getValueAnnotation = (data: any, index: number) => {
-  return {
-    x: data.yValues[0].values[index],
-    yref: index === 0 ? "y" : "y" + (index + 1),
-    text: data.yValues[0].values[index] + "%",
-    ...valueAnnotationProps,
   };
 };
 
@@ -83,14 +42,12 @@ const getYAxesLayout = (seriesCount: number) => {
 const getCompactBarLayout = (data: any, chartProps: ChartPropertyValues) => {
   let annotations;
   let categoryAnnotations = [];
-  let valueAnnotations = [];
 
   for (let i = 0; i < data.xValues[0].values.length; i++) {
     categoryAnnotations.push(getCategoryAnnotation(data, i));
-    valueAnnotations.push(getValueAnnotation(data, i));
   }
 
-  annotations = { annotations: [...categoryAnnotations, ...valueAnnotations] };
+  annotations = { annotations: [...categoryAnnotations] };
 
   const {
     height: rawHeight,
@@ -139,6 +96,12 @@ const getCompactBarTraces = (data: any) => {
     let trace: any = {
       y: [data.xValues[0].values[i]],
       x: [data.yValues[0].values[i]],
+      text: [data.yValues[0].values[i]],
+      textposition: "auto",
+      textfont: {
+        size: "16",
+        family: "Arial",
+      },
       yaxis: i === 0 ? "y" : "y" + (i + 1),
       marker: { color: seriesColor },
       hoverinfo: "none",

--- a/src/plotly/layout.ts
+++ b/src/plotly/layout.ts
@@ -101,4 +101,4 @@ const getMapLayout = (chartProps: ChartPropertyValues) => {
   return { ...commonLayout, ...mapLayout };
 };
 
-export { getMapLayout, getChartLayout };
+export { getMapLayout, getChartLayout, getCommonLayout };


### PR DESCRIPTION
Implementation of a new 'compact bar chart' type that can be used when category labels are particularly long. The chart positions category labels above each bar rather than beside them which leaves more horizontal space to display the bars themselves.

The implementation is semi bespoke and is loosely based on [this solution ](https://dkane.net/2020/better-horizontal-bar-charts-with-plotly/) that uses the Python version of Plotly and Dash. Unfortunately some of the useful helper functions available in the Python version are not available in Plotly.JS. 

The implementation uses two Plotly capabilities, subplots and annotations. In a nutshell we create one subplot for each bar to display and create an annotation to show the category label. Most of the standard plot features are hidden such as the axes, legend, zeroline, ticklabels, etc. 

There are further explanatory comments in compactBarChart.ts

