### PR TITLE
Issue 789/improve source link next to charts

### DIFF
--- a/src/components/button/DataLink.tsx
+++ b/src/components/button/DataLink.tsx
@@ -43,7 +43,7 @@ const DataLink: React.FC<Props> = ({ link, text }) => {
           rel="noopener noreferrer"
           href={link}
         >
-          {text} &#8594;
+          {text}
         </a>
       ) : (
         <div
@@ -54,7 +54,7 @@ const DataLink: React.FC<Props> = ({ link, text }) => {
             ...linkStyle,
           }}
         >
-          {text} &#8594;
+          {text}
         </div>
       )}
     </div>

--- a/src/components/button/DataLink.tsx
+++ b/src/components/button/DataLink.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+
+type Props = {
+  link: string;
+  text: string;
+};
+
+const DataLink: React.FC<Props> = ({ link, text }) => {
+  const linkStyle = {
+    color: "#1D70B8",
+    fontSize: "19px",
+    fontWeight: "bold",
+    textDecoration: "none",
+    paddingTop: "10px",
+    paddingBottom: "10px",
+    marginRight: "20px",
+    marginLeft: "20px",
+  };
+  const validateLink = () => {
+    if (link === "") {
+      return false;
+    }
+    if (link === null || link === undefined) {
+      return false;
+    }
+    return true;
+  };
+  const acceptableLink = validateLink();
+
+  return (
+    <div
+      style={{
+        width: "70%",
+        alignItems: "center",
+        justifyContent: "end",
+        display: "flex",
+      }}
+    >
+      {acceptableLink ? (
+        <a
+          style={{ ...linkStyle }}
+          target="_blank"
+          rel="noopener noreferrer"
+          href={link}
+        >
+          {text} &#8594;
+        </a>
+      ) : (
+        <div
+          style={{
+            textAlign: "end",
+            opacity: "0.2",
+            cursor: "not-allowed",
+            ...linkStyle,
+          }}
+        >
+          {text} &#8594;
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DataLink;

--- a/src/components/button/data-link.css
+++ b/src/components/button/data-link.css
@@ -1,0 +1,17 @@
+.data-link {
+  color: #1d70b8;
+  font-size: 19px;
+  font-weight: bold;
+  text-decoration: none;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  margin-right: 20px;
+  margin-left: 20px;
+}
+
+.data-link-wrapper {
+  width: 70%;
+  align-items: center;
+  justify-content: end;
+  display: flex;
+}

--- a/src/components/chart-preview/ChartPreview.tsx
+++ b/src/components/chart-preview/ChartPreview.tsx
@@ -43,7 +43,8 @@ export const ActualChart = ({
       </div>
     );
 
-  const { chartType, layout } = chartDefinition;
+  const { chartType, layout, exploreDataLink } = chartDefinition;
+
   // Incrementing the datarevision forces plotly to update the chart.
   // This is a workaround for an issue where plotly loses its
   // autorange calculations on component re-render.
@@ -107,7 +108,7 @@ export const ActualChart = ({
   return (
     <div id="chart">
       {chartType !== "table" ? (
-        <Tabs>
+        <Tabs link={exploreDataLink}>
           <Tab title="Visualisation">
             <Suspense fallback={<div />}>
               {isClientSideRender ? (

--- a/src/components/tabs/Tabs.tsx
+++ b/src/components/tabs/Tabs.tsx
@@ -1,11 +1,13 @@
 import React, { ReactElement, useState } from "react";
 import TabTitle from "./TabTitle";
+import DataLink from "../button/DataLink";
 
 type Props = {
+  link: string;
   children: ReactElement[];
 };
 
-const Tabs: React.FC<Props> = ({ children }) => {
+const Tabs: React.FC<Props> = ({ link, children }) => {
   const [selectedTab, setSelectedTab] = useState(0);
 
   return (
@@ -14,6 +16,7 @@ const Tabs: React.FC<Props> = ({ children }) => {
         style={{
           marginBottom: 40,
           display: "flex",
+          flexDirection: "row",
           listStyle: "none",
         }}
       >
@@ -26,6 +29,7 @@ const Tabs: React.FC<Props> = ({ children }) => {
             setSelectedTab={setSelectedTab}
           />
         ))}
+        <DataLink text={"Explore the data"} link={link} />
       </ul>
       {children[selectedTab]}
     </div>

--- a/src/context/ChartPropertiesSchema.ts
+++ b/src/context/ChartPropertiesSchema.ts
@@ -41,6 +41,20 @@ const GridlinesSection: ChartPropertySchemaSection = {
   ],
 };
 
+const exploreDataSection: ChartPropertySchemaSection = {
+  name: "exploreDataProperties",
+  displayName: "Explore data",
+  sectionFor: "charts",
+  properties: [
+    {
+      name: "exploreDataLink",
+      displayName: "Link",
+      type: "text",
+      defaultValue: "",
+    },
+  ],
+};
+
 const chartTypesSection: ChartPropertySchemaSection = {
   name: "chartTypes",
   displayName: "Chart type",
@@ -59,7 +73,7 @@ const chartTypesSection: ChartPropertySchemaSection = {
         "Map",
         "Filled Area",
         "Stacked Filled Area",
-        "Table"
+        "Table",
       ],
       defaultValue: "Line",
     },
@@ -362,6 +376,7 @@ const compactBarChartSection: ChartPropertySchemaSection = {
 };
 
 const chartPropertiesSchema: ChartPropertySchemaSection[] = [
+  exploreDataSection,
   chartTypesSection,
   orientationSection,
   chartDimensionsSection,

--- a/src/plotly/chartDefinition.ts
+++ b/src/plotly/chartDefinition.ts
@@ -34,8 +34,9 @@ const updateChartDefinition = (
     const commonLayout = getCommonLayout(chartProps);
     layout = { ...commonLayout, ...compactBarLayout };
   }
+  const exploreDataLink = chartProps.exploreDataProperties.exploreDataLink;
 
-  return { data, layout, config , chartType};
+  return { data, layout, config, chartType, exploreDataLink };
 };
 
 const getChartData = (


### PR DESCRIPTION
This creates a clickable link on the top right of a chart with text 'Explore this data'. The link address for this button is set in the side panel of chart builder, under the 'Explore data' section.

Reference image to go off
![image](https://user-images.githubusercontent.com/110108574/218795059-f1b6c6e6-f306-4a0e-93ea-6c2ca6c3b4db.png)

Outcome
![image](https://user-images.githubusercontent.com/110108574/218795448-56b3e719-adbb-4c5e-846b-3a5fcdbd0843.png)

Notes
- removed the proceeding arrow after a discussing with design
- when no link is set the button will be greyed out and disabled as below
![image](https://user-images.githubusercontent.com/110108574/218796050-ba643e84-2a91-467e-976b-a8d68fe998fe.png)
- by default on existing charts the button will be disabled