### PR TITLE
add an alternative chart type from chartDefinition

### DIFF
--- a/src/components/chart-preview/ChartPreview.tsx
+++ b/src/components/chart-preview/ChartPreview.tsx
@@ -43,7 +43,9 @@ export const ActualChart = ({
       </div>
     );
 
-  const { chartType, layout } = chartDefinition;
+  const { data, chartType, layout } = chartDefinition;
+  const altChartType = data?.[0]?.type;
+
   // Incrementing the datarevision forces plotly to update the chart.
   // This is a workaround for an issue where plotly loses its
   // autorange calculations on component re-render.
@@ -111,7 +113,7 @@ export const ActualChart = ({
           <Tab title="Visualisation">
             <Suspense fallback={<div />}>
               {isClientSideRender ? (
-                chartType === "map" ? (
+                chartType === "map" || altChartType === "choropleth" ? (
                   <PlotlyGeo chartDefinition={chartDefinition} />
                 ) : (
                   <PlotlyBasic chartDefinition={chartDefinition} />


### PR DESCRIPTION
An issue in chart builder was meaning older map charts (ones already on live sites) where not loading correctly.
Newer charts have their chartType set on creation but this was only introduced in a later build of chart builder.
Use an alternative chart type which is available in chartDefinition if chart type isn't available.

Was previously displaying as
![image](https://user-images.githubusercontent.com/110108574/219001917-950a8204-d512-4aaf-a55d-7f20b620e9bf.png)

Now will be correct:
![image](https://user-images.githubusercontent.com/110108574/219002085-a949c742-dd81-4dba-9acf-008e6b87b31c.png)

To test, copy the src folder from chart builder, go into the cms folder-> volto-> src-> addons-> chart-builder and replace the src folder within. Load up the CMS, with climate change and go to the adaptation dashboard.
