### PR TITLE
Issue 760/legend interactivity reminder

### DIFF
--- a/src/assets/icons/click-tap.svg
+++ b/src/assets/icons/click-tap.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M14.6586 11C14.8797 10.3744 15 9.70127 15 9C15 5.68629 12.3137 3 9 3C5.68629 3 3 5.68629 3 9C3 9.70127 3.12031 10.3744 3.34141 11" stroke="#505A5F" stroke-width="2" stroke-linecap="round"/>
+<path d="M7 21V12C7 10.8954 7.89543 10 9 10C10.1046 10 11 10.8954 11 12V15H14C16.2091 15 18 16.7909 18 19V21" stroke="#505A5F" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/chart-preview/ChartPreview.tsx
+++ b/src/components/chart-preview/ChartPreview.tsx
@@ -8,6 +8,8 @@ import Tab from "../tabs/Tab";
 import useChartDataToCsv from "../../hooks/useChartDataToCsv";
 import useSaveCsvData from "../../hooks/useSaveCsvData";
 
+import tap from "../../assets/icons/click-tap.svg";
+
 import domtoimage from "dom-to-image";
 import { saveAs } from "file-saver";
 
@@ -135,6 +137,12 @@ export const ActualChart = ({
         />
       )}
       <div className="non-content">
+        <div className="prompt-wrapper">
+          <img src={tap} />
+          <div className="prompt-text">
+            Click or tap on legend items to toggle visibility
+          </div>
+        </div>
         <h3 className="govuk-heading-s govuk-!-margin-bottom-2 non-content cb-download">
           Download
         </h3>

--- a/src/components/chart-preview/chart-preview.css
+++ b/src/components/chart-preview/chart-preview.css
@@ -26,3 +26,15 @@ ul {
   margin-left: 20px;
   cursor: pointer;
 }
+
+.prompt-wrapper {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+}
+
+.prompt-text {
+  color: #b1b4b6;
+  font-size: 16px;
+}

--- a/src/plotly/layout.ts
+++ b/src/plotly/layout.ts
@@ -77,7 +77,16 @@ const getChartLayout = (chartProps: ChartPropertyValues, data: any) => {
       },
       ...yAxisTickConfig,
     },
-    legend: { orientation: "h", y: chartProps.LegendSection.xAxisOffset },
+    legend: {
+      orientation: "h",
+      xanchor: "center",
+      x: 0.48,
+      y: chartProps.LegendSection.xAxisOffset,
+      font: {
+        family: "GDSTransportWebsite",
+        size: 16,
+      },
+    },
     showlegend: chartProps.LegendSection.showLegend,
   };
   return { ...commonLayout, ...chartLayout };


### PR DESCRIPTION
his ticket was to add a prompt to let users know they can toggle filters by clicking on the legend.
Design can be found [here](https://images.zenhubusercontent.com/62d6af6eae090a87615b5ca8/39e6e374-36c8-4fd0-95ab-5b5ed11a1294).

I've also centred the legend to bring it inline with designs as well as changing legend font to GDS Transport.