### PR TITLE
make LegendPrompt component

### DIFF
--- a/src/assets/icons/click-tap.svg
+++ b/src/assets/icons/click-tap.svg
@@ -1,4 +1,0 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M14.6586 11C14.8797 10.3744 15 9.70127 15 9C15 5.68629 12.3137 3 9 3C5.68629 3 3 5.68629 3 9C3 9.70127 3.12031 10.3744 3.34141 11" stroke="#505A5F" stroke-width="2" stroke-linecap="round"/>
-<path d="M7 21V12C7 10.8954 7.89543 10 9 10C10.1046 10 11 10.8954 11 12V15H14C16.2091 15 18 16.7909 18 19V21" stroke="#505A5F" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-</svg>

--- a/src/components/chart-preview/ChartPreview.tsx
+++ b/src/components/chart-preview/ChartPreview.tsx
@@ -8,7 +8,6 @@ import Tab from "../tabs/Tab";
 import useChartDataToCsv from "../../hooks/useChartDataToCsv";
 import useSaveCsvData from "../../hooks/useSaveCsvData";
 
-import tap from "../../assets/icons/click-tap.svg";
 import domtoimage from "dom-to-image";
 import { saveAs } from "file-saver";
 
@@ -206,12 +205,6 @@ export const ActualChart = ({
         />
       )}
       <div className="non-content">
-        <div className="prompt-wrapper">
-          <img src={tap} />
-          <div className="prompt-text">
-            Click or tap on legend items to toggle visibility
-          </div>
-        </div>
         <h3 className="govuk-heading-s govuk-!-margin-bottom-2 non-content cb-download">
           Download
         </h3>

--- a/src/components/chart-preview/PlotlyBasic.tsx
+++ b/src/components/chart-preview/PlotlyBasic.tsx
@@ -2,18 +2,9 @@
 import Plotly from "plotly.js-basic-dist-min";
 import createPlotlyComponent from "react-plotly.js/factory";
 import React, { useEffect, useState } from "react";
+import LegendPrompt from "../misc/LegendPrompt";
 
 const Plot: any = createPlotlyComponent(Plotly);
-
-const useFilters = (data: any) => {
-  const [filtersIndex, setFiltersIndex] = useState<number[]>([]);
-
-  useEffect(() => {
-    console.log("data", data);
-  }, [data]);
-
-  return { filtersIndex };
-};
 
 const PlotlyBasic = ({
   chartDefinition,
@@ -33,6 +24,7 @@ const PlotlyBasic = ({
         onLegendClick={(e: any) => onLegendClick(e)}
         onLegendDoubleClick={(e: any) => onLegendDoubleClick(e)}
       />
+      <LegendPrompt />
     </>
   );
 };

--- a/src/components/misc/LegendPrompt.tsx
+++ b/src/components/misc/LegendPrompt.tsx
@@ -1,0 +1,36 @@
+const PromptImage = () => (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M14.6586 11C14.8797 10.3744 15 9.70127 15 9C15 5.68629 12.3137 3 9 3C5.68629 3 3 5.68629 3 9C3 9.70127 3.12031 10.3744 3.34141 11\"
+      stroke="#505A5F"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+    <path
+      d="M7 21V12C7 10.8954 7.89543 10 9 10C10.1046 10 11 10.8954 11 12V15H14C16.2091 15 18 16.7909 18 19V21\"
+      stroke="#505A5F"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const LegendPrompt = () => {
+  return (
+    <div className="prompt-wrapper non-content">
+      <PromptImage />
+      <div className="prompt-text">
+        Click or tap on legend items to toggle visibility
+      </div>
+    </div>
+  );
+};
+
+export default LegendPrompt;


### PR DESCRIPTION
this was to fix an issue with the prompt icon not appearing once chart builder had been imported into the cms.
A separate LegendPrompt component has been created, with the svg in code rather than stored in the directory.
A workaround to get it to appear on both standalone and cms, with svgs not playing well with TypeScript and not needing to import and new modules.

Another issue was the prompt staying below when switching tabs. Fixed by moving LegendPrompt within PlotlyBasic.
![image](https://user-images.githubusercontent.com/110108574/228611862-92458f19-0af5-4c9d-bb27-97940c44a366.png)
