### PR TITLE
conditional check for undefined intervalStyle

### DIFF
--- a/src/context/ChartContextProvider.tsx
+++ b/src/context/ChartContextProvider.tsx
@@ -163,6 +163,7 @@ function useTidyDataToChartContext(
       };
 
       if (
+        series.intervalStyle !== undefined &&
         series.intervalStyle !== INTERVAL_STYLES[0] &&
         series.lowerBoundSeries !== "" &&
         series.upperBoundSeries !== ""


### PR DESCRIPTION
This fixes an issue when going to edit a figure on the cms. Older charts don't have the intervalStyle ect props.
![image](https://user-images.githubusercontent.com/110108574/229074275-f7e5aef0-0413-4e01-9986-f8bbec9c603d.png)
