### PR TITLE
rename GDSTransportWebsite to GDS Transport

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,10 +1,10 @@
 @font-face {
-  font-family: GDSTransportWebsite;
+  font-family: GDS Transport;
   src: url(./fonts/GDSTransportWebsite.ttf);
   font-weight: normal;
 }
 @font-face {
-  font-family: GDSTransportWebsite;
+  font-family: GDS Transport;
   src: url(./fonts/GDSTransportWebsite-Bold.ttf);
   font-weight: bold;
 }
@@ -16,7 +16,7 @@
 }
 
 body {
-  font-family: "GDSTransportWebsite", sans-serif;
+  font-family: "GDS Transport", sans-serif;
   font-size: 0.8rem;
   overflow-y: hidden;
 }

--- a/src/plotly/layout.ts
+++ b/src/plotly/layout.ts
@@ -83,7 +83,7 @@ const getChartLayout = (chartProps: ChartPropertyValues, data: any) => {
       x: 0.48,
       y: chartProps.LegendSection.xAxisOffset,
       font: {
-        family: "GDSTransportWebsite",
+        family: "GDS Transport",
         size: 16,
       },
     },


### PR DESCRIPTION
Rename font GDSTransportWebsite to GDS Transport, this is the same spelling as within the CMS.