### PR TITLE
change TabTitle to use <button>

### DIFF
--- a/src/components/chart-preview/chart-preview.css
+++ b/src/components/chart-preview/chart-preview.css
@@ -20,11 +20,14 @@ ul {
 .tab-button {
   /* display: inline-block; */
   font-size: 19px;
+
   padding-top: 10px;
   padding-bottom: 10px;
   margin-right: 20px;
   margin-left: 20px;
   cursor: pointer;
+  background-color: transparent;
+  border: 0;
 }
 
 .prompt-wrapper {

--- a/src/components/tabs/TabTitle.tsx
+++ b/src/components/tabs/TabTitle.tsx
@@ -20,7 +20,7 @@ const TabTitle: React.FC<Props> = ({
 
   return (
     <li style={{ width: 180 }} className="non-content">
-      <div
+      <button
         onClick={() => setSelectedTab(index)}
         style={{
           textAlign: "center",
@@ -30,7 +30,7 @@ const TabTitle: React.FC<Props> = ({
         className="tab-button"
       >
         {title}
-      </div>
+      </button>
     </li>
   );
 };


### PR DESCRIPTION
This ticket sorted an accessibility issue where pressing tab wouldn't highlight the tab titles.
You can now tab between them, pressing enter to switch between them.

![image](https://user-images.githubusercontent.com/110108574/233286552-ebca13b7-92e9-4d04-be6c-b0b1ba0d233e.png)
