### PR TITLE
Issue 887/automate legend font change

### DIFF
--- a/src/components/chart-preview/PlotlyBasic.tsx
+++ b/src/components/chart-preview/PlotlyBasic.tsx
@@ -6,6 +6,9 @@ import LegendPrompt from "../misc/LegendPrompt";
 const Plot: any = createPlotlyComponent(Plotly);
 
 const createNewLayout = (layout: { legend: { font: any } }) => {
+  // this function is a work around for having to force updated legend fonts
+  // rather than having to resave each chart manually
+
   const newFont = {
     ...layout.legend.font,
     size: 16,

--- a/src/components/chart-preview/PlotlyBasic.tsx
+++ b/src/components/chart-preview/PlotlyBasic.tsx
@@ -1,10 +1,29 @@
 // @ts-ignore
 import Plotly from "plotly.js-basic-dist-min";
 import createPlotlyComponent from "react-plotly.js/factory";
-import React, { useEffect, useState } from "react";
 import LegendPrompt from "../misc/LegendPrompt";
 
 const Plot: any = createPlotlyComponent(Plotly);
+
+const createNewLayout = (layout: { legend: { font: any } }) => {
+  const newFont = {
+    ...layout.legend.font,
+    size: 16,
+    family: "GDS Transport",
+  };
+
+  const newLayout = {
+    ...layout,
+    legend: {
+      ...layout.legend,
+      font: newFont,
+      xanchor: "center",
+      x: 0.48,
+    },
+  };
+
+  return newLayout;
+};
 
 const PlotlyBasic = ({
   chartDefinition,
@@ -12,12 +31,13 @@ const PlotlyBasic = ({
   onLegendDoubleClick,
 }: any) => {
   let { data, layout, config } = chartDefinition;
+  const newLayout = createNewLayout(layout);
 
   return (
     <>
       <Plot
         data={data}
-        layout={layout}
+        layout={newLayout}
         config={config}
         useResizeHandler={true}
         style={{ width: "100%" }}


### PR DESCRIPTION
Previously to get the updated legend font and have centred legends, users would have to go in and manually resave each chart, this ticket forced a new layout on each chart, so they don't have to be resaved.

**To test**
Copy the src folder from chart builder and paste into dd-cms/volto/src/addons/chart-builder, replacing the one in there. Then run a cms climate change instance, head to the adaptation dashboard (which currently has the old style for legends in prod), the charts should now have the updated styling. See below for before and after. 
The changes are, font is now 16px and GDS Transport, along with the legend being centred.

before
![image](https://github.com/GSS-Cogs/chart-builder/assets/110108574/749c631c-f5e1-4020-9b64-1831a252854a)

after
![image](https://github.com/GSS-Cogs/chart-builder/assets/110108574/162b8aff-6695-41f9-9381-502c9062119c)
