### PR TITLE
tickvals now uses tickLabels

### DIFF
--- a/src/plotly/axisTickLabels.ts
+++ b/src/plotly/axisTickLabels.ts
@@ -48,8 +48,7 @@ const getAxisTickConfig = (
 
     return {
       tickmode: "array",
-      tickvals: values,
-      ticktext: tickLabels,
+      tickvals: tickLabels,
       tickangle,
     };
   }


### PR DESCRIPTION
This ticket was to address a bug when setting ticks to manual, the hoverinfo would show blanks for the xaxis value, mirroring the blank values on the xaxis.

Before
![image](https://github.com/GSS-Cogs/chart-builder/assets/110108574/7a552aab-8a0b-4b21-9e20-76e0ed3098fd)

After
![image](https://github.com/GSS-Cogs/chart-builder/assets/110108574/630801fd-ec54-49b3-bd8a-f78f2e520544)
