### PR TITLE
add optional chaining

### DIFF
--- a/src/context/ChartContextProvider.tsx
+++ b/src/context/ChartContextProvider.tsx
@@ -284,7 +284,7 @@ function useEeaConnectorData(
 
       // Filter the measure column to get the (Y) values for the current series
       const yArray = (toFilter as any[]).filter<string | number>(
-        (_, index): _ is any => data[dimension][index] === series.name,
+        (_, index): _ is any => data[dimension]?.[index] === series.name,
       );
 
       // Build the X and Y values objects for the current series


### PR DESCRIPTION
This was to deal with an issue that would happen when updating chart data source/file, where the new data does not having matching names on the data columns, this would throw an error and not allowing updated data.

The fix in place returns undefined instead of throwing an error.
This will also cause the data columns with mismatched names to be blank.
![image](https://github.com/GSS-Cogs/chart-builder/assets/110108574/99a22feb-a5f9-4276-a704-b84d2408a7ce)
