### PR TITLE
issue-890/selectedColumns in chart builder has blank entries

### DIFF
--- a/src/components/side-panel/data-selection/DataSelection.tsx
+++ b/src/components/side-panel/data-selection/DataSelection.tsx
@@ -54,30 +54,19 @@ const DataSelection = (): JSX.Element => {
       return;
     }
 
-    let previousValue = "";
+    let newSelectedColumnNames = [...selectedColumns];
     switch (name) {
       case "xValues":
-        previousValue = dataSelection!.xValues;
+        newSelectedColumnNames[0] = value;
         break;
       case "measure":
-        previousValue = dataSelection!.measure;
+        newSelectedColumnNames[1] = value;
         break;
       case "dimension":
-        previousValue = dataSelection!.dimension;
+        newSelectedColumnNames[2] = value;
         break;
     }
-
-    if (previousValue) {
-      let newSelectedColumnNames = [];
-      const alreadySelectedColumnNames = selectedColumns.filter(
-        (item) => item !== previousValue,
-      );
-      newSelectedColumnNames.push(...alreadySelectedColumnNames);
-      newSelectedColumnNames.push(value);
-      setSelectedColumns(newSelectedColumnNames);
-    } else {
-      setSelectedColumns([...selectedColumns, value]);
-    }
+    setSelectedColumns(newSelectedColumnNames);
     setDataSelection((prevState: any) => ({
       ...prevState,
       [name]: value,


### PR DESCRIPTION
to get the first column name for the data view of chart builder, selectedColumns is passed in.
selectedColumns holds the names of the data columns.
Previously when setting selectedColumns changed it would replace the previous entry with blank and push a new name to the end of selectedColumns. This would mean when the data view came to grab the first column name it would grab the wrong one.
This new method simplifies the process and gives each data column a fixed position, so the first entry will always be the correct name.

![image](https://github.com/GSS-Cogs/chart-builder/assets/110108574/f5e66eee-eb7c-4b61-83cb-5b598d662eb4)
