### PR TITLE
move isClientSideRender

### DIFF
--- a/src/components/chart-preview/ChartPreview.tsx
+++ b/src/components/chart-preview/ChartPreview.tsx
@@ -177,9 +177,9 @@ export const ActualChart = ({
       {chartType !== "table" ? (
         <Tabs link={exploreDataLink}>
           <Tab title="Visualisation">
-            <Suspense fallback={<div />}>
-              {isClientSideRender ? (
-                chartType === "map" || altChartType === "choropleth" ? (
+            {isClientSideRender ? (
+              <Suspense fallback={<div />}>
+                {chartType === "map" || altChartType === "choropleth" ? (
                   <PlotlyGeo chartDefinition={chartDefinition} />
                 ) : (
                   <PlotlyBasic
@@ -187,9 +187,9 @@ export const ActualChart = ({
                     onLegendClick={onLegendClick}
                     onLegendDoubleClick={onLegendDoubleClick}
                   />
-                )
-              ) : null}
-            </Suspense>
+                )}
+              </Suspense>
+            ) : null}
           </Tab>
           <Tab title="Chart Data">
             <TabularData


### PR DESCRIPTION
This ticket was to deal with an error when refreshing standalone figure blocks.

I've moved `isClientSideRender` to contain the `<Suspense />` component, rather than the other way round.

**To test**
Run a local build of the cms, login, and head into a figure.
![image](https://github.com/GSS-Cogs/chart-builder/assets/110108574/fd01a151-b28c-49bd-8635-96c06069f267)
Hit refresh and you should be hit with the error.
![image](https://github.com/GSS-Cogs/chart-builder/assets/110108574/f1d916bc-04e1-464d-9eb9-75e88153ecfb)
After
Copy the src folder for chart builder into the local build of the cms, within the add-on chart builder folder. Replacing the on inside.
Go back to the loaded figure, hit refresh, and the error should not appear.