### PR TITLE
@babel/preset-react dev dependency

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,7 @@
     "es2021": true,
     "node": true
   },
-  "extends": ["plugin:react/recommended", "plugin:storybook/recommended"],
+  "extends": ["plugin:react/recommended"],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaFeatures": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     ]
   },
   "devDependencies": {
+    "@babel/preset-react": "^7.22.5",
     "@testing-library/jest-dom": "^5.16.1",
     "@testing-library/react": "^12.1.2",
     "@testing-library/react-hooks": "^8.0.0",


### PR DESCRIPTION
When "@storybook/react" was removed it also had some dependencies that where needed when chart builder was brought into the cms.
This adds "@babel/preset-react" the main dev dependency needed.

Also removed "plugin:storybook/recommended" from .eslintrc.json