### PR TITLE
conditional on .font

### DIFF
--- a/src/components/chart-preview/PlotlyBasic.tsx
+++ b/src/components/chart-preview/PlotlyBasic.tsx
@@ -10,7 +10,7 @@ const createNewLayout = (layout: { legend: { font: any } }) => {
   // rather than having to resave each chart manually
 
   const newFont = {
-    ...layout.legend.font,
+    ...layout.legend?.font,
     size: 16,
     family: "GDS Transport",
   };


### PR DESCRIPTION
This fixes an undefined font issue when switching to compact bar charts.

![image](https://github.com/GSS-Cogs/chart-builder/assets/110108574/d499dd2d-01ff-42cf-846f-082c7bd10d0f)
